### PR TITLE
Adjust scripting for GitHub's new default branch name, and minor zsh syntax improvements

### DIFF
--- a/install.zsh
+++ b/install.zsh
@@ -83,7 +83,7 @@ function install_node() {
 
 function install_vim_start_packages() {
   local current_dir
-  current_dir=$(eval "pwd")
+  current_dir=$(pwd)
 
   cd "$VIM_DIR/pack/packages/start"
 
@@ -105,7 +105,7 @@ function install_vim_start_packages() {
 
 function install_vim_opt_packages() {
   local current_dir
-  current_dir=$(eval "pwd")
+  current_dir=$(pwd)
 
   cd "$VIM_DIR/pack/packages/opt"
 

--- a/zsh/custom/plugins/git-scotttesler/git-scotttesler.plugin.zsh
+++ b/zsh/custom/plugins/git-scotttesler/git-scotttesler.plugin.zsh
@@ -1,8 +1,9 @@
 function db() {
-  local current_branch=`eval "git rev-parse --abbrev-ref HEAD"`
+  local current_branch=$(git rev-parse --abbrev-ref HEAD)
+  local default_branch=$(git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@')
 
-  if [[ "$current_branch" == "master" ]]; then
-    echo "Current branch is master. Cannot delete master."
+  if [[ "$current_branch" == "$default_branch" ]]; then
+    echo "Current branch is $default_branch. Cannot delete $default_branch."
     return 0
   fi
 
@@ -14,7 +15,7 @@ function db() {
     esac
   done
 
-  git checkout master
+  git checkout $default_branch
   git branch -D $current_branch
   gf
 }

--- a/zsh/custom/plugins/node-scotttesler/node-scotttesler.plugin.zsh
+++ b/zsh/custom/plugins/node-scotttesler/node-scotttesler.plugin.zsh
@@ -4,7 +4,7 @@ function install_latest_node() {
     exit 1
   fi
 
-  local current_node=`eval "nvm current"`
+  local current_node=$(nvm current)
 
   nvm install node
   nvm alias default node

--- a/zsh/custom/plugins/updates-scotttesler/updates-scotttesler.plugin.zsh
+++ b/zsh/custom/plugins/updates-scotttesler/updates-scotttesler.plugin.zsh
@@ -6,7 +6,7 @@ function brewu() {
 }
 
 function upd() {
-  local current_dir=`eval "pwd"`
+  local current_dir=$(pwd)
 
   if ( user_has brew ); then
     brewu

--- a/zsh/custom/plugins/vim-scotttesler/vim-scotttesler.plugin.zsh
+++ b/zsh/custom/plugins/vim-scotttesler/vim-scotttesler.plugin.zsh
@@ -1,5 +1,5 @@
 function updateVimPackages() {
-  local current_dir=`eval "pwd"`
+  local current_dir=$(pwd)
   local vim_dir="$HOME/.vim"
 
   if [[ ! -d "$vim_dir" ]]; then


### PR DESCRIPTION
> The default branch name for new repositories created on GitHub is now `main`.

https://github.com/github/renaming/tree/040636ea50e945875c70cc964d586f645e9bd810#new-repositories-use-main-as-the-default-branch-name